### PR TITLE
Add a buffering middleware

### DIFF
--- a/bullenetwork/directus/docker-compose.yml
+++ b/bullenetwork/directus/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         - traefik.http.routers.bn_directus.tls.certresolver=leresolver
         - traefik.http.services.bn_directus.loadbalancer.server.port=8055
         - traefik.http.routers.bn_directus.middlewares=bn_file_transfer
-        - traefik.http.middlewares.bn_file_transfer.buffering.memRequestBodyBytes=512000000 # 512 MB
+        - traefik.http.middlewares.bn_file_transfer.buffering.maxRequestBodyBytes=512000000 # 512 MB
     depends_on:
       - cache
       - database

--- a/bullenetwork/directus/docker-compose.yml
+++ b/bullenetwork/directus/docker-compose.yml
@@ -51,6 +51,8 @@ services:
         - traefik.http.routers.bn_directus.entrypoints=websecure
         - traefik.http.routers.bn_directus.tls.certresolver=leresolver
         - traefik.http.services.bn_directus.loadbalancer.server.port=8055
+        - traefik.http.routers.bn_directus.middlewares=bn_file_transfer
+        - traefik.http.middlewares.bn_file_transfer.buffering.memRequestBodyBytes=512000000 # 512 MB
     depends_on:
       - cache
       - database


### PR DESCRIPTION
Let the requests sent to directus be up to 512 MB.